### PR TITLE
HEXXLE-72 and HEXXLE-73: Camera Controls

### DIFF
--- a/unity/Assets/Scenes/main/Main.unity
+++ b/unity/Assets/Scenes/main/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -999,6 +999,7 @@ GameObject:
   - component: {fileID: 1466212395}
   - component: {fileID: 1466212394}
   - component: {fileID: 1466212393}
+  - component: {fileID: 1466212396}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1071,6 +1072,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 25, y: 0, z: 0}
+--- !u!114 &1466212396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1466212392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2d87e2eba9054e47a418378ccb70a8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  zoomStep: 0.5
+  maxZoom: 10
+  moveSpeed: 5
 --- !u!1 &1498164355
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scripts/Unity/Input/InputManager.cs
+++ b/unity/Assets/Scripts/Unity/Input/InputManager.cs
@@ -67,6 +67,151 @@ public class @InputManager : IInputActionCollection, IDisposable
                     ""isPartOfComposite"": false
                 }
             ]
+        },
+        {
+            ""name"": ""CameraMovement"",
+            ""id"": ""911f02e1-9526-4281-aacf-bf2264f22694"",
+            ""actions"": [
+                {
+                    ""name"": ""Move"",
+                    ""type"": ""Value"",
+                    ""id"": ""6fdbd460-ba95-4202-beb1-d80886c3a3bc"",
+                    ""expectedControlType"": ""Vector2"",
+                    ""processors"": """",
+                    ""interactions"": """"
+                },
+                {
+                    ""name"": ""Zoom"",
+                    ""type"": ""Value"",
+                    ""id"": ""f8c8f6ca-6e5c-4078-8365-1dc3de381583"",
+                    ""expectedControlType"": ""Axis"",
+                    ""processors"": """",
+                    ""interactions"": """"
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""79eb0345-0434-456d-ac89-50c7dd7aabb1"",
+                    ""path"": ""<Mouse>/scroll"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Zoom"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""Keyboard WASD"",
+                    ""id"": ""1edd01ae-a473-49d7-aab5-d2e040796081"",
+                    ""path"": ""2DVector"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Move"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""up"",
+                    ""id"": ""1ae6ee74-214c-4c36-a04e-a4bb9d6104c6"",
+                    ""path"": ""<Keyboard>/w"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""down"",
+                    ""id"": ""032e25e4-e8df-47a8-a99c-bdb161266c9b"",
+                    ""path"": ""<Keyboard>/s"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""left"",
+                    ""id"": ""6a4751e9-3cd4-4b22-b59b-1e2bd1264730"",
+                    ""path"": ""<Keyboard>/a"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""right"",
+                    ""id"": ""b90c6e10-41ff-428e-b7fb-7e434c311f29"",
+                    ""path"": ""<Keyboard>/d"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard Arrows"",
+                    ""id"": ""37b7613e-9c81-45da-a907-0dce4d075da5"",
+                    ""path"": ""2DVector"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Move"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""up"",
+                    ""id"": ""c5837279-8e42-46ed-ba9b-5e8085c0a522"",
+                    ""path"": ""<Keyboard>/upArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""down"",
+                    ""id"": ""7966c6e8-f203-4fbe-a762-76d592a3f077"",
+                    ""path"": ""<Keyboard>/downArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""left"",
+                    ""id"": ""a95ba138-3927-4416-ace7-80236a39f6d4"",
+                    ""path"": ""<Keyboard>/leftArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""right"",
+                    ""id"": ""f5bf0ae4-da61-429d-9f5d-c67944bdb4f1"",
+                    ""path"": ""<Keyboard>/rightArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard and Mouse"",
+                    ""action"": ""Move"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                }
+            ]
         }
     ],
     ""controlSchemes"": [
@@ -85,6 +230,16 @@ public class @InputManager : IInputActionCollection, IDisposable
                     ""isOR"": false
                 }
             ]
+        },
+        {
+            ""name"": ""Touch Only"",
+            ""bindingGroup"": ""Touch Only"",
+            ""devices"": []
+        },
+        {
+            ""name"": ""Gamepad"",
+            ""bindingGroup"": ""Gamepad"",
+            ""devices"": []
         }
     ]
 }");
@@ -94,6 +249,10 @@ public class @InputManager : IInputActionCollection, IDisposable
         // TilePlacement
         m_TilePlacement = asset.FindActionMap("TilePlacement", throwIfNotFound: true);
         m_TilePlacement_MouseClick = m_TilePlacement.FindAction("MouseClick", throwIfNotFound: true);
+        // CameraMovement
+        m_CameraMovement = asset.FindActionMap("CameraMovement", throwIfNotFound: true);
+        m_CameraMovement_Move = m_CameraMovement.FindAction("Move", throwIfNotFound: true);
+        m_CameraMovement_Zoom = m_CameraMovement.FindAction("Zoom", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -205,6 +364,47 @@ public class @InputManager : IInputActionCollection, IDisposable
         }
     }
     public TilePlacementActions @TilePlacement => new TilePlacementActions(this);
+
+    // CameraMovement
+    private readonly InputActionMap m_CameraMovement;
+    private ICameraMovementActions m_CameraMovementActionsCallbackInterface;
+    private readonly InputAction m_CameraMovement_Move;
+    private readonly InputAction m_CameraMovement_Zoom;
+    public struct CameraMovementActions
+    {
+        private @InputManager m_Wrapper;
+        public CameraMovementActions(@InputManager wrapper) { m_Wrapper = wrapper; }
+        public InputAction @Move => m_Wrapper.m_CameraMovement_Move;
+        public InputAction @Zoom => m_Wrapper.m_CameraMovement_Zoom;
+        public InputActionMap Get() { return m_Wrapper.m_CameraMovement; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(CameraMovementActions set) { return set.Get(); }
+        public void SetCallbacks(ICameraMovementActions instance)
+        {
+            if (m_Wrapper.m_CameraMovementActionsCallbackInterface != null)
+            {
+                @Move.started -= m_Wrapper.m_CameraMovementActionsCallbackInterface.OnMove;
+                @Move.performed -= m_Wrapper.m_CameraMovementActionsCallbackInterface.OnMove;
+                @Move.canceled -= m_Wrapper.m_CameraMovementActionsCallbackInterface.OnMove;
+                @Zoom.started -= m_Wrapper.m_CameraMovementActionsCallbackInterface.OnZoom;
+                @Zoom.performed -= m_Wrapper.m_CameraMovementActionsCallbackInterface.OnZoom;
+                @Zoom.canceled -= m_Wrapper.m_CameraMovementActionsCallbackInterface.OnZoom;
+            }
+            m_Wrapper.m_CameraMovementActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @Move.started += instance.OnMove;
+                @Move.performed += instance.OnMove;
+                @Move.canceled += instance.OnMove;
+                @Zoom.started += instance.OnZoom;
+                @Zoom.performed += instance.OnZoom;
+                @Zoom.canceled += instance.OnZoom;
+            }
+        }
+    }
+    public CameraMovementActions @CameraMovement => new CameraMovementActions(this);
     private int m_KeyboardandMouseSchemeIndex = -1;
     public InputControlScheme KeyboardandMouseScheme
     {
@@ -214,6 +414,24 @@ public class @InputManager : IInputActionCollection, IDisposable
             return asset.controlSchemes[m_KeyboardandMouseSchemeIndex];
         }
     }
+    private int m_TouchOnlySchemeIndex = -1;
+    public InputControlScheme TouchOnlyScheme
+    {
+        get
+        {
+            if (m_TouchOnlySchemeIndex == -1) m_TouchOnlySchemeIndex = asset.FindControlSchemeIndex("Touch Only");
+            return asset.controlSchemes[m_TouchOnlySchemeIndex];
+        }
+    }
+    private int m_GamepadSchemeIndex = -1;
+    public InputControlScheme GamepadScheme
+    {
+        get
+        {
+            if (m_GamepadSchemeIndex == -1) m_GamepadSchemeIndex = asset.FindControlSchemeIndex("Gamepad");
+            return asset.controlSchemes[m_GamepadSchemeIndex];
+        }
+    }
     public interface IMenuInteractionActions
     {
         void OnPause(InputAction.CallbackContext context);
@@ -221,5 +439,10 @@ public class @InputManager : IInputActionCollection, IDisposable
     public interface ITilePlacementActions
     {
         void OnMouseClick(InputAction.CallbackContext context);
+    }
+    public interface ICameraMovementActions
+    {
+        void OnMove(InputAction.CallbackContext context);
+        void OnZoom(InputAction.CallbackContext context);
     }
 }

--- a/unity/Assets/Scripts/Unity/Input/InputManager.inputactions
+++ b/unity/Assets/Scripts/Unity/Input/InputManager.inputactions
@@ -54,6 +54,151 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "CameraMovement",
+            "id": "911f02e1-9526-4281-aacf-bf2264f22694",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "6fdbd460-ba95-4202-beb1-d80886c3a3bc",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Zoom",
+                    "type": "Value",
+                    "id": "f8c8f6ca-6e5c-4078-8365-1dc3de381583",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "79eb0345-0434-456d-ac89-50c7dd7aabb1",
+                    "path": "<Mouse>/scroll",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Zoom",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Keyboard WASD",
+                    "id": "1edd01ae-a473-49d7-aab5-d2e040796081",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "1ae6ee74-214c-4c36-a04e-a4bb9d6104c6",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "032e25e4-e8df-47a8-a99c-bdb161266c9b",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "6a4751e9-3cd4-4b22-b59b-1e2bd1264730",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "b90c6e10-41ff-428e-b7fb-7e434c311f29",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard Arrows",
+                    "id": "37b7613e-9c81-45da-a907-0dce4d075da5",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "c5837279-8e42-46ed-ba9b-5e8085c0a522",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "7966c6e8-f203-4fbe-a762-76d592a3f077",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "a95ba138-3927-4416-ace7-80236a39f6d4",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "f5bf0ae4-da61-429d-9f5d-c67944bdb4f1",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard and Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                }
+            ]
         }
     ],
     "controlSchemes": [
@@ -72,6 +217,16 @@
                     "isOR": false
                 }
             ]
+        },
+        {
+            "name": "Touch Only",
+            "bindingGroup": "Touch Only",
+            "devices": []
+        },
+        {
+            "name": "Gamepad",
+            "bindingGroup": "Gamepad",
+            "devices": []
         }
     ]
 }

--- a/unity/Assets/Scripts/Unity/UnityCamera.cs
+++ b/unity/Assets/Scripts/Unity/UnityCamera.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class UnityCamera : MonoBehaviour
+{
+    public float zoomStep;
+    public float maxZoom;
+    public float moveSpeed;
+
+    private InputManager inputManager;
+    private Vector3 direction;
+    private bool held;
+
+    private void Awake()
+    {
+        inputManager = new InputManager();
+
+        inputManager.CameraMovement.Zoom.Enable();
+        inputManager.CameraMovement.Move.canceled += context => MoveCamera(context);
+        inputManager.CameraMovement.Zoom.performed += context => ZoomCamera(context);
+
+        inputManager.CameraMovement.Move.Enable();
+        inputManager.CameraMovement.Move.performed += context => MoveCamera(context);
+    }
+
+    private void Update()
+    {
+        if (held) Camera.main.transform.Translate(direction * moveSpeed * Time.deltaTime);
+    }
+
+    private void ZoomCamera(InputAction.CallbackContext context)
+    {
+        int zoomDirection = context.ReadValue<Vector2>().y > 0 ? -1 : 1;
+        float newOrthographicSize = Camera.main.orthographicSize + zoomStep * zoomDirection;
+
+        if (0 < newOrthographicSize && newOrthographicSize < maxZoom + zoomStep)  Camera.main.orthographicSize = newOrthographicSize;
+    }
+
+    private void MoveCamera(InputAction.CallbackContext context)
+    {
+        direction = context.ReadValue<Vector2>();
+        if (context.performed) held = true;
+        if (context.canceled) held = false;
+    }
+}

--- a/unity/Assets/Scripts/Unity/UnityCamera.cs.meta
+++ b/unity/Assets/Scripts/Unity/UnityCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2d87e2eba9054e47a418378ccb70a8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/PlayMode/Unity/CameraMovementTests.cs
+++ b/unity/Assets/Tests/PlayMode/Unity/CameraMovementTests.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Utilities;
+
+namespace Hexxle.Tests.Unity
+{
+    public class CameraMovementTests : InputTestFixture
+    {
+        Keyboard keyboard;
+        Mouse mouse;
+        InputManager inputManager;
+
+        InputAction movementAction;
+        InputAction zoomAction;
+
+        [SetUp]
+        public void Setup()
+        {
+            keyboard = InputSystem.AddDevice<Keyboard>();
+            mouse = InputSystem.AddDevice<Mouse>();
+            inputManager = new InputManager();
+            movementAction = inputManager.CameraMovement.Move;
+            zoomAction = inputManager.CameraMovement.Zoom;
+            SceneManager.LoadScene("Main", LoadSceneMode.Single);
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollingDownIncreasesCameraSize()
+        {
+            float initialSize = Camera.main.orthographicSize;
+            zoomAction.Enable();
+            Move(mouse.scroll, new Vector2(0, -1));
+
+            using (var trace = new InputActionTrace())
+            {
+                trace.SubscribeTo(zoomAction);
+                zoomAction.Disable();
+
+                Assert.AreEqual(1, trace.count);
+            }
+            yield return new WaitForSecondsRealtime(1);
+            Assert.Greater(Camera.main.orthographicSize, initialSize);
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollingUpDecreasesCameraSize()
+        {
+            float initialSize = Camera.main.orthographicSize;
+            zoomAction.Enable();
+            Move(mouse.scroll, new Vector2(0,1));
+
+            using (var trace = new InputActionTrace())
+            {
+                trace.SubscribeTo(zoomAction);
+                zoomAction.Disable();
+
+                Assert.AreEqual(1, trace.count);
+            }
+            yield return new WaitForSecondsRealtime(1);
+            Assert.Less(Camera.main.orthographicSize, initialSize);
+        }
+
+        [UnityTest]
+        public IEnumerator PressingWIncreasesYPosition()
+        {
+            float initialY = Camera.main.transform.position.y;
+            movementAction.Enable();
+            Press(keyboard.wKey);
+
+            using (var trace = new InputActionTrace())
+            {
+                trace.SubscribeTo(movementAction);
+                movementAction.Disable();
+
+                Assert.AreEqual(1, trace.count);
+            }
+            yield return new WaitForSecondsRealtime(1);
+            Assert.Greater(Camera.main.transform.position.y, initialY);
+        }
+
+        [UnityTest]
+        public IEnumerator PressingSDecreasesYPosition()
+        {
+            float initialY = Camera.main.transform.position.y;
+            movementAction.Enable();
+            Press(keyboard.sKey);
+
+            using (var trace = new InputActionTrace())
+            {
+                trace.SubscribeTo(movementAction);
+                movementAction.Disable();
+
+                Assert.AreEqual(1, trace.count);
+            }
+            yield return new WaitForSecondsRealtime(1);
+            Assert.Less(Camera.main.transform.position.y, initialY);
+        }
+
+        [UnityTest]
+        public IEnumerator PressingDIncreasesXPosition()
+        {
+            float initialX = Camera.main.transform.position.x;
+            movementAction.Enable();
+            Press(keyboard.dKey);
+
+            using (var trace = new InputActionTrace())
+            {
+                trace.SubscribeTo(movementAction);
+                movementAction.Disable();
+
+                Assert.AreEqual(1, trace.count);
+            }
+            yield return new WaitForSecondsRealtime(1);
+            Assert.Greater(Camera.main.transform.position.x, initialX);
+        }
+
+        [UnityTest]
+        public IEnumerator PressingADecreasesXPosition()
+        {
+            float initialX = Camera.main.transform.position.x;
+            movementAction.Enable();
+            Press(keyboard.aKey);
+
+            using (var trace = new InputActionTrace())
+            {
+                trace.SubscribeTo(movementAction);
+                movementAction.Disable();
+
+                Assert.AreEqual(1, trace.count);
+            }
+            yield return new WaitForSecondsRealtime(1);
+            Assert.Less(Camera.main.transform.position.x, initialX);
+        }
+    }
+}

--- a/unity/Assets/Tests/PlayMode/Unity/CameraMovementTests.cs.meta
+++ b/unity/Assets/Tests/PlayMode/Unity/CameraMovementTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e529feff66c75234f993cbafd60631c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implemented the basic features necessary for simple camera controls: This includes:

- Camera movement using WASD and arrow keys
- Camera zoom using the mouse scroll wheels
- In theory, support for many more input devices (hip and cool Unity Input System)
- Select few public variables for configuring things like camera speed
- Six units tests (PlayMode) that all run successfully