### PR TITLE
Bug/hexxle 93 incorrect tiles

### DIFF
--- a/unity/Assets/Scripts/CoordinateSystem/Coordinate.cs
+++ b/unity/Assets/Scripts/CoordinateSystem/Coordinate.cs
@@ -1,17 +1,125 @@
+using System;
+using UnityEngine;
+
 namespace Hexxle.CoordinateSystem
 {
     public struct Coordinate
     {
-        public int x { get; set; }
-        public int y { get; set; }
-        public int z { get; set; }
-
-
-        public Coordinate(int x, int y, int z)
+        // Implementation heavily derived from https://www.redblobgames.com/grids/hexagons/
+        public struct Hex
         {
-            this.x = x;
-            this.y = y;
-            this.z = z;
+            public float Q { get; }
+            public float R { get; }
+            
+            public Hex(float q, float r)
+            {
+                this.Q = q;
+                this.R = r;
+            }
+        }
+
+        public struct Cube
+        {
+            public float X { get; }
+            public float Y { get; }
+            public float Z { get; }
+
+            public Cube(float x, float y, float z)
+            {
+                this.X = x;
+                this.Y = y;
+                this.Z = z;
+            }
+        }
+
+        private Hex _hex;
+        private Cube _cube;
+
+        public int Q => Convert.ToInt32(_hex.Q);
+        public int R => Convert.ToInt32(_hex.R);
+        public int X => Convert.ToInt32(_cube.X);
+        public int Y => Convert.ToInt32(_cube.Y);
+        public int Z => Convert.ToInt32(_cube.Z);
+
+        public Coordinate(Hex hex)
+        {
+            this._hex = hex;
+            this._cube = AxialToCube(hex);
+        }
+
+        public Coordinate(Cube cube)
+        {
+            this._cube = cube;
+            this._hex = CubeToAxial(cube);
+        }
+
+        public Coordinate(int x, int y, int z) : this(new Cube(x, y, z)) { }
+        public Coordinate(float x, float y, float z)
+        {
+            this._cube = CubeRound(new Cube(x, y, z));
+            this._hex = CubeToAxial(this._cube);
+        }
+
+        private static Cube CubeRound(Cube cube)
+        {
+            // rounded values
+            int rx = Mathf.RoundToInt(cube.X);
+            int ry = Mathf.RoundToInt(cube.Y);
+            int rz = Mathf.RoundToInt(cube.Z);
+
+            // Apply x+y+z = 0 constraint
+            var xdiff = Mathf.Abs(rx - cube.X);
+            var ydiff = Mathf.Abs(ry - cube.Y);
+            var zdiff = Mathf.Abs(rz - cube.Z);
+
+            if (xdiff > ydiff && xdiff > zdiff)
+            {
+                rx = -ry - rz;
+            }
+            else if (ydiff > zdiff)
+            {
+                ry = -rx - rz;
+            }
+            else
+            {
+                rz = -rx - ry;
+            }
+            return new Cube(rx, ry, rz);
+        }
+
+        private static Hex HexRound(Hex hex)
+        {
+            return CubeToAxial(CubeRound(AxialToCube(hex)));
+        }
+
+        private static Hex CubeToAxial(Cube cube)
+        {
+            var q = cube.X;
+            var r = cube.Z;
+            return new Hex(q, r);
+        }
+
+        public static Cube AxialToCube(Hex hex)
+        {
+            var x = hex.Q;
+            var z = hex.R;
+            var y = -x - z;
+            return new Cube(x, y, z);
+        }
+
+        public static Vector3 CoordinateToPoint(Coordinate coordinate)
+        {
+            var x = Mathf.Sqrt(3) * coordinate._hex.Q + Mathf.Sqrt(3) / 2 * coordinate._hex.R;
+            var z = 3f / 2 * coordinate._hex.R;
+            return new Vector3(x, 0, z);
+        }
+
+        public static Coordinate PointToCoordinate(Vector3 point)
+        {
+            var q = Mathf.Sqrt(3) / 3 * point.x - 1f / 3 * point.z;
+            var r = 2f / 3 * point.z;
+            Hex roundedHex = HexRound(new Hex(q, r));
+            return new Coordinate(roundedHex);
         }
     }
 }

--- a/unity/Assets/Scripts/Logic/TileMap.cs
+++ b/unity/Assets/Scripts/Logic/TileMap.cs
@@ -40,5 +40,10 @@ namespace Hexxle.Logic
         {
             throw new NotImplementedException();
         }
+
+        public int TileCount()
+        {
+            return _axisDictionary.Count;
+        }
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Nature/CircleNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/CircleNature.cs
@@ -17,12 +17,12 @@ namespace Hexxle.TileSystem.Nature
         {
             var relevantCoordinates = new List<Coordinate>
             {
-                new Coordinate(coordinate.x + 1, coordinate.y - 1, coordinate.z),
-                new Coordinate(coordinate.x + 1, coordinate.y, coordinate.z - 1),
-                new Coordinate(coordinate.x, coordinate.y + 1, coordinate.z - 1),
-                new Coordinate(coordinate.x - 1, coordinate.y + 1, coordinate.z),
-                new Coordinate(coordinate.x - 1, coordinate.y, coordinate.z + 1),
-                new Coordinate(coordinate.x, coordinate.y - 1, coordinate.z + 1),
+                new Coordinate(coordinate.X + 1, coordinate.Y - 1, coordinate.Z),
+                new Coordinate(coordinate.X + 1, coordinate.Y, coordinate.Z - 1),
+                new Coordinate(coordinate.X, coordinate.Y + 1, coordinate.Z - 1),
+                new Coordinate(coordinate.X - 1, coordinate.Y + 1, coordinate.Z),
+                new Coordinate(coordinate.X - 1, coordinate.Y, coordinate.Z + 1),
+                new Coordinate(coordinate.X, coordinate.Y - 1, coordinate.Z + 1),
             };
             return relevantCoordinates;
         }

--- a/unity/Assets/Scripts/Unity/UnityCamera.cs
+++ b/unity/Assets/Scripts/Unity/UnityCamera.cs
@@ -27,7 +27,11 @@ public class UnityCamera : MonoBehaviour
 
     private void Update()
     {
-        if (held) Camera.main.transform.Translate(direction * moveSpeed * Time.deltaTime);
+        if (held) 
+        {
+            Vector3 relative = Camera.main.transform.InverseTransformDirection(direction * moveSpeed * Time.deltaTime);
+            Camera.main.transform.Translate(relative);
+        }
     }
 
     private void ZoomCamera(InputAction.CallbackContext context)
@@ -40,7 +44,9 @@ public class UnityCamera : MonoBehaviour
 
     private void MoveCamera(InputAction.CallbackContext context)
     {
-        direction = context.ReadValue<Vector2>();
+        var moveVector = context.ReadValue<Vector2>();
+        direction.x = moveVector.x;
+        direction.z = moveVector.y;
         if (context.performed) held = true;
         if (context.canceled) held = false;
     }

--- a/unity/Assets/Scripts/Unity/UnityMap.cs
+++ b/unity/Assets/Scripts/Unity/UnityMap.cs
@@ -55,7 +55,9 @@ namespace Hexxle.Unity
                         GameObject clickedTile = hit.collider.gameObject;
 
                         Coordinate coordinate = PointToCoordinate(clickedTile.transform.position);
-                        Debug.Log(coordinate.x + " " + coordinate.y + " " + coordinate.z);
+                        Debug.Log(
+                            $"Coordinate: {coordinate.X} {coordinate.Y} {coordinate.Z}\n" +
+                            $"Point: {clickedTile.transform.position.ToString()}");
                         PlaceNextTile(coordinate);
 
                         GameObject.Destroy(clickedTile);
@@ -119,18 +121,17 @@ namespace Hexxle.Unity
 
         private Coordinate PointToCoordinate(Vector3 point)
         {
-            int x = (int)Mathf.Round((Mathf.Sqrt(3f) / 3f * point.x - (point.z / 3f)) / OuterTileRadius);
-            int y = (int)Mathf.Round(-(Mathf.Sqrt(3f) / 3f * point.x + (point.z / 3f)) / OuterTileRadius);
-            int z = (int)(2f / 3f * point.z / OuterTileRadius);
-            return new Coordinate(x, y, z);
+            // Modify point by OuterTileRadius
+            var p = point / OuterTileRadius;
+            return Coordinate.PointToCoordinate(p);
         }
 
         private Vector3 CoordinateToPoint(Coordinate coordinate)
         {
-            // see https://stackoverflow.com/questions/2459402/hexagonal-grid-coordinates-to-pixel-coordinates
-            float x = Mathf.Sqrt(3f) * OuterTileRadius * (coordinate.z / 2f + coordinate.x);
-            float z = 3f / 2f * coordinate.z * OuterTileRadius;
-            return new Vector3(x, 0, z);
+            var p = Coordinate.CoordinateToPoint(coordinate);
+            // Modify point by OuterTileRadius
+            p *= OuterTileRadius;
+            return p;
         }
 
         private void OnTilePlaced(object sender, TileMapEventArgs<ITile> e)

--- a/unity/Assets/Tests/EditMode/Logic/CoordinateTests.cs
+++ b/unity/Assets/Tests/EditMode/Logic/CoordinateTests.cs
@@ -1,0 +1,41 @@
+﻿using Hexxle.CoordinateSystem;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Hexxle.Tests.Logic
+{
+    public class CoordinateTests
+    {
+        [Test]
+        public void Conversion_Hexxle91()
+        {
+            float outerTileRadius = 0.57f;
+
+            Coordinate expected1 = new Coordinate(-9, -9, 18);
+            Coordinate expected2 = new Coordinate(-10, -9, 19);
+
+            var testPoint1 = Coordinate.CoordinateToPoint(expected1) * outerTileRadius;
+            var testPoint2 = Coordinate.CoordinateToPoint(expected2) * outerTileRadius;
+
+            var actualConversion1 = Coordinate.PointToCoordinate(testPoint1 / outerTileRadius);
+            var actualConversion2 = Coordinate.PointToCoordinate(testPoint2 / outerTileRadius);
+
+            Assert.AreEqual(expected1, actualConversion1);
+            Assert.AreEqual(expected2, actualConversion2);
+        }
+
+        [Test]
+        public void PointToCoordinate_Hexxle91()
+        {
+            float outerTileRadius = 0.57f;
+
+            Vector3 point1 = new Vector3(0.0f, 0.0f, 15.4f);
+            Vector3 point2 = new Vector3(-0.5f, 0.0f, 16.2f);
+
+            var testCoord1 = Coordinate.PointToCoordinate(point1 / outerTileRadius);
+            var testCoord2 = Coordinate.PointToCoordinate(point2 / outerTileRadius);
+
+            Assert.AreNotEqual(testCoord1, testCoord2);
+        }
+    }
+}

--- a/unity/Assets/Tests/EditMode/Logic/CoordinateTests.cs.meta
+++ b/unity/Assets/Tests/EditMode/Logic/CoordinateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b23e26e8a40817348a14c7d894b9e644
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
+++ b/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
@@ -40,5 +40,14 @@ namespace Hexxle.Tests.Logic
             Assert.AreEqual(tile, tileMap.GetTile(coordinate));
         }
 
+        [Test]
+        public void PlaceTile_Hexxle91()
+        {
+            Coordinate c1 = new Coordinate(-8, -8, 16);
+            Coordinate c2 = new Coordinate(-9, -8, 17);
+            tileMap.PlaceTile(tile, c1);
+            tileMap.PlaceTile(tile, c2);
+            Assert.True(tileMap.TileCount() == 2);
+        }
     }
 }

--- a/unity/Assets/Tests/PlayMode/Unity/CameraMovementTests.cs
+++ b/unity/Assets/Tests/PlayMode/Unity/CameraMovementTests.cs
@@ -65,9 +65,9 @@ namespace Hexxle.Tests.Unity
         }
 
         [UnityTest]
-        public IEnumerator PressingWIncreasesYPosition()
+        public IEnumerator PressingWIncreasesZPosition()
         {
-            float initialY = Camera.main.transform.position.y;
+            float initialZ = Camera.main.transform.position.z;
             movementAction.Enable();
             Press(keyboard.wKey);
 
@@ -79,13 +79,13 @@ namespace Hexxle.Tests.Unity
                 Assert.AreEqual(1, trace.count);
             }
             yield return new WaitForSecondsRealtime(1);
-            Assert.Greater(Camera.main.transform.position.y, initialY);
+            Assert.Greater(Camera.main.transform.position.z, initialZ);
         }
 
         [UnityTest]
-        public IEnumerator PressingSDecreasesYPosition()
+        public IEnumerator PressingSDecreasesZPosition()
         {
-            float initialY = Camera.main.transform.position.y;
+            float initialZ = Camera.main.transform.position.z;
             movementAction.Enable();
             Press(keyboard.sKey);
 
@@ -97,7 +97,7 @@ namespace Hexxle.Tests.Unity
                 Assert.AreEqual(1, trace.count);
             }
             yield return new WaitForSecondsRealtime(1);
-            Assert.Less(Camera.main.transform.position.y, initialY);
+            Assert.Less(Camera.main.transform.position.z, initialZ);
         }
 
         [UnityTest]

--- a/unity/EditMode.csproj
+++ b/unity/EditMode.csproj
@@ -262,11 +262,26 @@
     <Reference Include="UnityEditor.WebGL.Extensions">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/WebGLSupport/UnityEditor.WebGL.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEditor.Android.Extensions">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/AndroidPlayer/UnityEditor.Android.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.UWP.Extensions">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/MetroSupport/UnityEditor.UWP.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="SyntaxTree.VisualStudio.Unity.Bridge">
       <HintPath>C:/Program Files (x86)/Microsoft Visual Studio Tools for Unity/16.0/Editor/SyntaxTree.VisualStudio.Unity.Bridge.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/PackageCache/com.unity.ext.nunit@1.0.6/net35/unity-custom/nunit.framework.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/PackageCache/com.unity.ext.nunit@1.0.6/net35/unity-custom/nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions.Xcode">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.Xcode.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions.Common">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.Common.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/MonoBleedingEdge/lib/mono/4.7.1-api/mscorlib.dll</HintPath>
@@ -622,37 +637,32 @@
     <Reference Include="Boo.Lang">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/MonoBleedingEdge/lib/mono/unityscript/Boo.Lang.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.TestRunner">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.TestRunner.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.TestRunner">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.TestRunner.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.InputSystem">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.InputSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.InputSystem.TestFramework">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.InputSystem.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.TextMeshPro.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEditor.UI">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.UI.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.UI.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="UnityEngine.TestRunner.csproj">
-      <Project>{7F5633AA-FF44-497D-9629-F9A7DB2F14FB}</Project>
-      <Name>UnityEngine.TestRunner</Name>
-    </ProjectReference>
-    <ProjectReference Include="UnityEditor.TestRunner.csproj">
-      <Project>{00FA63EE-66F3-34A4-D434-A87722E49AF8}</Project>
-      <Name>UnityEditor.TestRunner</Name>
-    </ProjectReference>
     <ProjectReference Include="Scripts.csproj">
       <Project>{BA4A617E-2A4A-391C-1435-AFCA02E0062B}</Project>
       <Name>Scripts</Name>
-    </ProjectReference>
-    <ProjectReference Include="Unity.InputSystem.csproj">
-      <Project>{720346F4-F464-B896-D392-0281C0555DA6}</Project>
-      <Name>Unity.InputSystem</Name>
-    </ProjectReference>
-    <ProjectReference Include="Unity.InputSystem.TestFramework.csproj">
-      <Project>{3F54D6FA-F525-6438-BDB8-C2B77CF6E852}</Project>
-      <Name>Unity.InputSystem.TestFramework</Name>
-    </ProjectReference>
-    <ProjectReference Include="Unity.TextMeshPro.csproj">
-      <Project>{0EC6B5F2-0218-AE7B-3C70-1901B4B53FF9}</Project>
-      <Name>Unity.TextMeshPro</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/unity/EditMode.csproj
+++ b/unity/EditMode.csproj
@@ -64,6 +64,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assets\Tests\EditMode\Logic\CoordinateTests.cs" />
     <Compile Include="Assets\Tests\EditMode\Logic\ScoreTests.cs" />
     <Compile Include="Assets\Tests\EditMode\Logic\TileMapTests.cs" />
     <None Include="Assets\Tests\EditMode\EditMode.asmdef" />

--- a/unity/PlayMode.csproj
+++ b/unity/PlayMode.csproj
@@ -252,7 +252,13 @@
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/Managed/UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/PackageCache/com.unity.ext.nunit@1.0.6/net35/unity-custom/nunit.framework.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/PackageCache/com.unity.ext.nunit@1.0.6/net35/unity-custom/nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions.Xcode">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.Xcode.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions.Common">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.Common.dll</HintPath>
     </Reference>
     <Reference Include="netstandard">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/NetStandard/ref/2.0.0/netstandard.dll</HintPath>
@@ -599,33 +605,29 @@
     <Reference Include="System.Xml.Serialization">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/NetStandard/compat/2.0.0/shims/netfx/System.Xml.Serialization.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.TestRunner">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.TestRunner.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.TestRunner">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.TestRunner.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.InputSystem">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.InputSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.InputSystem.TestFramework">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.InputSystem.TestFramework.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEditor.UI">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.UI.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.UI.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="UnityEngine.TestRunner.csproj">
-      <Project>{7F5633AA-FF44-497D-9629-F9A7DB2F14FB}</Project>
-      <Name>UnityEngine.TestRunner</Name>
-    </ProjectReference>
-    <ProjectReference Include="UnityEditor.TestRunner.csproj">
-      <Project>{00FA63EE-66F3-34A4-D434-A87722E49AF8}</Project>
-      <Name>UnityEditor.TestRunner</Name>
-    </ProjectReference>
     <ProjectReference Include="Scripts.csproj">
       <Project>{BA4A617E-2A4A-391C-1435-AFCA02E0062B}</Project>
       <Name>Scripts</Name>
-    </ProjectReference>
-    <ProjectReference Include="Unity.InputSystem.csproj">
-      <Project>{720346F4-F464-B896-D392-0281C0555DA6}</Project>
-      <Name>Unity.InputSystem</Name>
-    </ProjectReference>
-    <ProjectReference Include="Unity.InputSystem.TestFramework.csproj">
-      <Project>{3F54D6FA-F525-6438-BDB8-C2B77CF6E852}</Project>
-      <Name>Unity.InputSystem.TestFramework</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/unity/Scripts.csproj
+++ b/unity/Scripts.csproj
@@ -296,8 +296,23 @@
     <Reference Include="UnityEditor.WebGL.Extensions">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/WebGLSupport/UnityEditor.WebGL.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEditor.Android.Extensions">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/AndroidPlayer/UnityEditor.Android.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.UWP.Extensions">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/MetroSupport/UnityEditor.UWP.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="SyntaxTree.VisualStudio.Unity.Bridge">
       <HintPath>C:/Program Files (x86)/Microsoft Visual Studio Tools for Unity/16.0/Editor/SyntaxTree.VisualStudio.Unity.Bridge.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions.Xcode">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.Xcode.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.iOS.Extensions.Common">
+      <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/PlaybackEngines/iOSSupport/UnityEditor.iOS.Extensions.Common.dll</HintPath>
     </Reference>
     <Reference Include="netstandard">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/NetStandard/ref/2.0.0/netstandard.dll</HintPath>
@@ -644,23 +659,20 @@
     <Reference Include="System.Xml.Serialization">
       <HintPath>C:/Program Files/Unity/Hub/Editor/2019.4.22f1/Editor/Data/NetStandard/compat/2.0.0/shims/netfx/System.Xml.Serialization.dll</HintPath>
     </Reference>
+    <Reference Include="Unity.InputSystem">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.InputSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/Unity.TextMeshPro.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEditor.UI">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.UI.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEditor.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>C:/Users/ricar/Documents/GitHub/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.UI.dll</HintPath>
+      <HintPath>E:/Exchange/ZHAW/FS2021/PSIT4/Hexxle/hexxle_game/unity/Library/ScriptAssemblies/UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="Unity.InputSystem.csproj">
-      <Project>{720346F4-F464-B896-D392-0281C0555DA6}</Project>
-      <Name>Unity.InputSystem</Name>
-    </ProjectReference>
-    <ProjectReference Include="Unity.TextMeshPro.csproj">
-      <Project>{0EC6B5F2-0218-AE7B-3C70-1901B4B53FF9}</Project>
-      <Name>Unity.TextMeshPro</Name>
-    </ProjectReference>
-  </ItemGroup>
+  <ItemGroup></ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="GenerateTargetFrameworkMonikerAttribute" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Incorrect rounding sometimes caused a mouseclick at a certain point to be registered as a different tile's space.

* Fixed rounding
* Coordinate conversion is now done by the Coordinate class
* Added tests with specific values derived from the bug