### PR TITLE
Feature/hexxle 99 additional behaviours

### DIFF
--- a/unity/Assets/Prefabs/Hexagon_Template.prefab
+++ b/unity/Assets/Prefabs/Hexagon_Template.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1876366972912273574}
   - component: {fileID: 4462722653595565164}
   - component: {fileID: 577020052745392044}
+  - component: {fileID: -1880745732569702886}
   m_Layer: 0
   m_Name: Hexagon_Template
   m_TagString: Void
@@ -107,3 +108,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d55af2aef464f6c48882d3b27a87e473, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &-1880745732569702886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2805244402447506873}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07468b90e0fb2144da819491763f27e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  materials:
+  - {fileID: 2100000, guid: a40dfeecfd8aba804960a7199c538c47, type: 2}
+  - {fileID: 2100000, guid: 3e661a0623c2ca79b8553e0cf71d06bb, type: 2}
+  - {fileID: 2100000, guid: 856b9cd9c20e1df659276ce684600d9f, type: 2}
+  - {fileID: 2100000, guid: 95338a5fb01ca039799b71bdb63fc8e0, type: 2}
+  - {fileID: 2100000, guid: be292b7323a223f47be7b20f48f1d240, type: 2}
+  - {fileID: 2100000, guid: f0c8fc80d7143d140a4cf813acc25932, type: 2}
+  - {fileID: 2100000, guid: f0c8fc80d7143d140a4cf813acc25932, type: 2}

--- a/unity/Assets/Scripts/CoordinateSystem/Coordinate.cs
+++ b/unity/Assets/Scripts/CoordinateSystem/Coordinate.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Hexxle.CoordinateSystem
@@ -121,5 +122,19 @@ namespace Hexxle.CoordinateSystem
             Hex roundedHex = HexRound(new Hex(q, r));
             return new Coordinate(roundedHex);
         }
+
+        public IEnumerable<Coordinate> AdjacentCoordinates()
+        {
+            var relevantCoordinates = new List<Coordinate>
+            {
+                new Coordinate(X + 1, Y - 1, Z),
+                new Coordinate(X + 1, Y, Z - 1),
+                new Coordinate(X, Y + 1, Z - 1),
+                new Coordinate(X - 1, Y + 1, Z),
+                new Coordinate(X - 1, Y, Z + 1),
+                new Coordinate(X, Y - 1, Z + 1),
+            };
+            return relevantCoordinates;
+        } 
     }
 }

--- a/unity/Assets/Scripts/Interfaces/ITile.cs
+++ b/unity/Assets/Scripts/Interfaces/ITile.cs
@@ -8,6 +8,7 @@ namespace Hexxle.Interfaces
     {
         #region Events
         event Action TileChangedEvent;
+        event Action<Coordinate> RemovalRequestedEvent;
         #endregion
         #region Data
         Coordinate Coordinate { get; set; }
@@ -15,6 +16,9 @@ namespace Hexxle.Interfaces
         ITileType Type { get; set; }
         ITileBehaviour Behaviour { get; set; }
         ITileNature Nature { get; set; }
+        #endregion
+        #region Logic
+        void RequestRemoval();
         #endregion
     }
 }

--- a/unity/Assets/Scripts/Interfaces/ITile.cs
+++ b/unity/Assets/Scripts/Interfaces/ITile.cs
@@ -1,10 +1,14 @@
 ﻿using Hexxle.CoordinateSystem;
 using Hexxle.TileSystem;
+using System;
 
 namespace Hexxle.Interfaces
 {
     public interface ITile
     {
+        #region Events
+        event Action TileChangedEvent;
+        #endregion
         #region Data
         Coordinate Coordinate { get; set; }
         EState State { get; set; }

--- a/unity/Assets/Scripts/Interfaces/ITileBehaviour.cs
+++ b/unity/Assets/Scripts/Interfaces/ITileBehaviour.cs
@@ -5,6 +5,6 @@ namespace Hexxle.Interfaces
     public interface ITileBehaviour
     {
         EBehaviour Behaviour { get; }
-        void ApplyBehaviour(ITile otherTile);
+        void ApplyBehaviour(ITile originalTile, ITile otherTile);
     }
 }

--- a/unity/Assets/Scripts/Interfaces/ITileMap.cs
+++ b/unity/Assets/Scripts/Interfaces/ITileMap.cs
@@ -6,7 +6,7 @@ namespace Hexxle.Interfaces
     public interface ITileMap<T> where T : class, ITile
     {
         void PlaceTile(T tile, Coordinate coordinate);
-        T RemoveTile(T tile);
+        void RemoveTile(Coordinate coordinate);
         T GetTile(Coordinate coordinate);
         bool IsEmpty(Coordinate coordinate);
         event EventHandler<TileMapEventArgs<T>> TilePlaced;

--- a/unity/Assets/Scripts/Interfaces/ITileNature.cs
+++ b/unity/Assets/Scripts/Interfaces/ITileNature.cs
@@ -8,6 +8,5 @@ namespace Hexxle.Interfaces
     {
         ENature Nature { get; }
         IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate);
-        IEnumerable<Coordinate> AdjacentCoordinates(Coordinate coordinate);
     }
 }

--- a/unity/Assets/Scripts/Interfaces/ITileNature.cs
+++ b/unity/Assets/Scripts/Interfaces/ITileNature.cs
@@ -7,7 +7,7 @@ namespace Hexxle.Interfaces
     public interface ITileNature
     {
         ENature Nature { get; }
-        List<Coordinate> RelevantCoordinates(Coordinate coordinate);
-        List<Coordinate> AdjacentCoordinates(Coordinate coordinate);
+        IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate);
+        IEnumerable<Coordinate> AdjacentCoordinates(Coordinate coordinate);
     }
 }

--- a/unity/Assets/Scripts/Logic/TileMap.cs
+++ b/unity/Assets/Scripts/Logic/TileMap.cs
@@ -12,6 +12,7 @@ namespace Hexxle.Logic
     {
         private readonly Dictionary<Coordinate, ITile> _axisDictionary = new Dictionary<Coordinate, ITile>();
 
+        #region ITileMap interface implementation
         public event EventHandler<TileMapEventArgs<ITile>> TilePlaced;
         public event EventHandler<TileMapEventArgs<ITile>> TileRemoved;
 
@@ -28,7 +29,7 @@ namespace Hexxle.Logic
             TilePlaced?.Invoke(this, new TileMapEventArgs<ITile>(this, tile));
 
             // Place necessary void neighbours
-            var neighbours = tile.Nature.AdjacentCoordinates(tile.Coordinate);
+            var neighbours = tile.Coordinate.AdjacentCoordinates();
             foreach(Coordinate neighbouringCoordinate in neighbours)
             {
                 if (IsEmpty(neighbouringCoordinate))
@@ -51,7 +52,7 @@ namespace Hexxle.Logic
             _axisDictionary.Remove(tile.Coordinate);
 
             // check adjacent tiles
-            var neighbours = tile.Nature.AdjacentCoordinates(tile.Coordinate);
+            var neighbours = tile.Coordinate.AdjacentCoordinates();
             var neighbouringTiles = neighbours.Select(c => GetTile(c)).Where(t => t != null);
             foreach (ITile neighbouringTile in neighbouringTiles)
             {
@@ -64,6 +65,7 @@ namespace Hexxle.Logic
             TileRemoved?.Invoke(this, new TileMapEventArgs<ITile>(this, tile));
             return tile;
         }
+        #endregion
 
         public int NonVoidTileCount()
         {
@@ -75,7 +77,7 @@ namespace Hexxle.Logic
             bool isOrphaned = false;
             if (!(tile.Type.Type > EType.Void))
             {
-                var neighbours = tile.Nature.AdjacentCoordinates(tile.Coordinate);
+                var neighbours = tile.Coordinate.AdjacentCoordinates();
                 var neighbouringTiles = neighbours.Select(c => GetTile(c)).Where(t => t != null);
                 bool hasNonVoidNeighbours = neighbouringTiles.Any(t => t.Type.Type > EType.Void);
                 isOrphaned = !hasNonVoidNeighbours;

--- a/unity/Assets/Scripts/Logic/TileResolver.cs
+++ b/unity/Assets/Scripts/Logic/TileResolver.cs
@@ -13,13 +13,27 @@ namespace Hexxle.Logic
         public void ApplyBehaviour(ITile tile)
         {
             tile.Nature.RelevantCoordinates(tile.Coordinate)
-                .ForEach(coordinate => tile.Behaviour.ApplyBehaviour(_map.GetTile(coordinate)));
+                .ForEach(coordinate => {
+                    var otherTile = _map.GetTile(coordinate);
+                    if (otherTile is ITile)
+                    {
+                        tile.Behaviour.ApplyBehaviour(tile, _map.GetTile(coordinate));
+                    }
+                });
         }
 
         public int CalculatePoints(ITile tile)
         {
             return tile.Nature.RelevantCoordinates(tile.Coordinate)
-                .Sum(coordinate => _map.GetTile(coordinate) != null ? tile.Type.ValueOfRelationshipTo(_map.GetTile(coordinate).Type.Type) : 0);
+                .Sum(coordinate => {
+                    int points = 0;
+                    var otherTile = _map.GetTile(coordinate);
+                    if (otherTile is ITile)
+                    {
+                        points = tile.Type.ValueOfRelationshipTo(otherTile.Type.Type);
+                    }
+                    return points; 
+                });
         }
     }
 }

--- a/unity/Assets/Scripts/Logic/TileResolver.cs
+++ b/unity/Assets/Scripts/Logic/TileResolver.cs
@@ -1,4 +1,6 @@
-﻿using Hexxle.Interfaces;
+﻿using Hexxle.CoordinateSystem;
+using Hexxle.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Hexxle.Logic
@@ -12,14 +14,15 @@ namespace Hexxle.Logic
         }
         public void ApplyBehaviour(ITile tile)
         {
-            tile.Nature.RelevantCoordinates(tile.Coordinate)
-                .ForEach(coordinate => {
-                    var otherTile = _map.GetTile(coordinate);
-                    if (otherTile is ITile)
-                    {
-                        tile.Behaviour.ApplyBehaviour(tile, _map.GetTile(coordinate));
-                    }
-                });
+            IEnumerable<Coordinate> relevantCoordinates = tile.Nature.RelevantCoordinates(tile.Coordinate);
+            foreach (Coordinate coordinate in relevantCoordinates)
+            {
+                var otherTile = _map.GetTile(coordinate);
+                if (otherTile is ITile)
+                {
+                    tile.Behaviour.ApplyBehaviour(tile, _map.GetTile(coordinate));
+                }
+            }
         }
 
         public int CalculatePoints(ITile tile)

--- a/unity/Assets/Scripts/Logic/TileStack.cs
+++ b/unity/Assets/Scripts/Logic/TileStack.cs
@@ -82,7 +82,8 @@ namespace Hexxle.Logic
         {
             EType randomType = (EType)Random.Range(2, System.Enum.GetValues(typeof(EType)).Length); // None, Void < 2
             ENature randomNature = (ENature)Random.Range(1, System.Enum.GetValues(typeof(ENature)).Length);
-            ITile randomTile = Tile.CreateInstance(EState.OnField, randomType, randomNature, EBehaviour.NoEffect);
+            EBehaviour randomBehaviour = (EBehaviour)Random.Range(1, System.Enum.GetValues(typeof(EBehaviour)).Length);
+            ITile randomTile = Tile.CreateInstance(EState.OnField, randomType, randomNature, randomBehaviour);
             return randomTile;
         }
     }

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs
@@ -1,0 +1,19 @@
+﻿using Hexxle.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hexxle.TileSystem.Behaviour
+{
+    public class ConsumptionBehaviour : ITileBehaviour
+    {
+        public EBehaviour Behaviour => throw new NotImplementedException();
+
+        public void ApplyBehaviour(ITile otherTile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs
@@ -9,11 +9,14 @@ namespace Hexxle.TileSystem.Behaviour
 {
     public class ConsumptionBehaviour : ITileBehaviour
     {
-        public EBehaviour Behaviour => throw new NotImplementedException();
+        public EBehaviour Behaviour => EBehaviour.Consumption;
 
         public void ApplyBehaviour(ITile originalTile, ITile otherTile)
         {
-            throw new NotImplementedException();
+            if (!(otherTile.Type.Type is EType.Void))
+            {
+                otherTile.RequestRemoval();
+            }
         }
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs
@@ -11,7 +11,7 @@ namespace Hexxle.TileSystem.Behaviour
     {
         public EBehaviour Behaviour => throw new NotImplementedException();
 
-        public void ApplyBehaviour(ITile otherTile)
+        public void ApplyBehaviour(ITile originalTile, ITile otherTile)
         {
             throw new NotImplementedException();
         }

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs.meta
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConsumptionBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac13b0ed1878668449c9ad9dfec39523
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs
@@ -11,9 +11,12 @@ namespace Hexxle.TileSystem.Behaviour
     {
         public EBehaviour Behaviour => throw new NotImplementedException();
 
-        public void ApplyBehaviour(ITile otherTile)
+        public void ApplyBehaviour(ITile originalTile, ITile otherTile)
         {
-            throw new NotImplementedException();
+            if (!(otherTile.Type.Type is EType.Void))
+            {
+                otherTile.Type = (ITileType)Activator.CreateInstance(originalTile.Type.GetType());
+            }
         }
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs
@@ -9,7 +9,7 @@ namespace Hexxle.TileSystem.Behaviour
 {
     public class ConversionBehaviour : ITileBehaviour
     {
-        public EBehaviour Behaviour => throw new NotImplementedException();
+        public EBehaviour Behaviour => EBehaviour.Conversion;
 
         public void ApplyBehaviour(ITile originalTile, ITile otherTile)
         {

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs
@@ -1,0 +1,19 @@
+﻿using Hexxle.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hexxle.TileSystem.Behaviour
+{
+    public class ConversionBehaviour : ITileBehaviour
+    {
+        public EBehaviour Behaviour => throw new NotImplementedException();
+
+        public void ApplyBehaviour(ITile otherTile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs.meta
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/ConversionBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a13380ff18d3254091057509a6c86aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Scripts/TileSystem/Behaviour/NoEffectBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/Behaviour/NoEffectBehaviour.cs
@@ -6,7 +6,7 @@ namespace Hexxle.TileSystem.Behaviour
     {
         public EBehaviour Behaviour => EBehaviour.NoEffect;
 
-        public void ApplyBehaviour(ITile otherTile)
+        public void ApplyBehaviour(ITile originalTile, ITile otherTile)
         {
             // Do nothing
         }

--- a/unity/Assets/Scripts/TileSystem/EBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/EBehaviour.cs
@@ -3,6 +3,7 @@
     public enum EBehaviour
     {
         None,
-        NoEffect
+        NoEffect,
+        Conversion
     }
 }

--- a/unity/Assets/Scripts/TileSystem/EBehaviour.cs
+++ b/unity/Assets/Scripts/TileSystem/EBehaviour.cs
@@ -4,6 +4,7 @@
     {
         None,
         NoEffect,
-        Conversion
+        Conversion,
+        Consumption
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Nature/BaseTileNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/BaseTileNature.cs
@@ -12,20 +12,6 @@ namespace Hexxle.TileSystem.Nature
     {
         public abstract ENature Nature { get; }
 
-        public IEnumerable<Coordinate> AdjacentCoordinates(Coordinate coordinate)
-        {
-            var relevantCoordinates = new List<Coordinate>
-            {
-                new Coordinate(coordinate.X + 1, coordinate.Y - 1, coordinate.Z),
-                new Coordinate(coordinate.X + 1, coordinate.Y, coordinate.Z - 1),
-                new Coordinate(coordinate.X, coordinate.Y + 1, coordinate.Z - 1),
-                new Coordinate(coordinate.X - 1, coordinate.Y + 1, coordinate.Z),
-                new Coordinate(coordinate.X - 1, coordinate.Y, coordinate.Z + 1),
-                new Coordinate(coordinate.X, coordinate.Y - 1, coordinate.Z + 1),
-            };
-            return relevantCoordinates;
-        }
-
         public abstract IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate);
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Nature/BaseTileNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/BaseTileNature.cs
@@ -12,7 +12,7 @@ namespace Hexxle.TileSystem.Nature
     {
         public abstract ENature Nature { get; }
 
-        public List<Coordinate> AdjacentCoordinates(Coordinate coordinate)
+        public IEnumerable<Coordinate> AdjacentCoordinates(Coordinate coordinate)
         {
             var relevantCoordinates = new List<Coordinate>
             {
@@ -26,6 +26,6 @@ namespace Hexxle.TileSystem.Nature
             return relevantCoordinates;
         }
 
-        public abstract List<Coordinate> RelevantCoordinates(Coordinate coordinate);
+        public abstract IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate);
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Nature/CircleNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/CircleNature.cs
@@ -8,7 +8,7 @@ namespace Hexxle.TileSystem.Nature
     {
         public override ENature Nature => ENature.Circle;
 
-        public override List<Coordinate> RelevantCoordinates(Coordinate coordinate)
+        public override IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate)
         {
             return AdjacentCoordinates(coordinate);
         }

--- a/unity/Assets/Scripts/TileSystem/Nature/CircleNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/CircleNature.cs
@@ -10,7 +10,7 @@ namespace Hexxle.TileSystem.Nature
 
         public override IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate)
         {
-            return AdjacentCoordinates(coordinate);
+            return coordinate.AdjacentCoordinates();
         }
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Nature/StarNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/StarNature.cs
@@ -14,7 +14,7 @@ namespace Hexxle.TileSystem.Nature
 
         public override IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate)
         {
-            var relevantCoordinates = AdjacentCoordinates(coordinate);
+            var relevantCoordinates = coordinate.AdjacentCoordinates();
             relevantCoordinates.Concat(new List<Coordinate>
             {
                 new Coordinate(coordinate.X - 1, coordinate.Y - 1, coordinate.Z + 2),

--- a/unity/Assets/Scripts/TileSystem/Nature/StarNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/StarNature.cs
@@ -15,7 +15,7 @@ namespace Hexxle.TileSystem.Nature
         public override IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate)
         {
             var relevantCoordinates = coordinate.AdjacentCoordinates();
-            relevantCoordinates.Concat(new List<Coordinate>
+            relevantCoordinates = relevantCoordinates.Concat(new List<Coordinate>
             {
                 new Coordinate(coordinate.X - 1, coordinate.Y - 1, coordinate.Z + 2),
                 new Coordinate(coordinate.X + 1, coordinate.Y - 2, coordinate.Z + 1),

--- a/unity/Assets/Scripts/TileSystem/Nature/StarNature.cs
+++ b/unity/Assets/Scripts/TileSystem/Nature/StarNature.cs
@@ -12,10 +12,10 @@ namespace Hexxle.TileSystem.Nature
     {
         public override ENature Nature => ENature.Star;
 
-        public override List<Coordinate> RelevantCoordinates(Coordinate coordinate)
+        public override IEnumerable<Coordinate> RelevantCoordinates(Coordinate coordinate)
         {
             var relevantCoordinates = AdjacentCoordinates(coordinate);
-            relevantCoordinates.AddRange(new List<Coordinate>
+            relevantCoordinates.Concat(new List<Coordinate>
             {
                 new Coordinate(coordinate.X - 1, coordinate.Y - 1, coordinate.Z + 2),
                 new Coordinate(coordinate.X + 1, coordinate.Y - 2, coordinate.Z + 1),

--- a/unity/Assets/Scripts/TileSystem/Tile.cs
+++ b/unity/Assets/Scripts/TileSystem/Tile.cs
@@ -40,6 +40,9 @@ namespace Hexxle.TileSystem
                 case EBehaviour.NoEffect:
                     tileBehaviour = new NoEffectBehaviour();
                     break;
+                case EBehaviour.Conversion:
+                    tileBehaviour = new ConversionBehaviour();
+                    break;
                 case EBehaviour.None:
                 default:
                     tileBehaviour = null;

--- a/unity/Assets/Scripts/TileSystem/Tile.cs
+++ b/unity/Assets/Scripts/TileSystem/Tile.cs
@@ -16,6 +16,7 @@ namespace Hexxle.TileSystem
         private ITileNature _nature;
 
         public event Action TileChangedEvent;
+        public event Action<Coordinate> RemovalRequestedEvent;
 
         private Tile()
         {
@@ -149,5 +150,9 @@ namespace Hexxle.TileSystem
             }
         }
 
+        public void RequestRemoval()
+        {
+            RemovalRequestedEvent?.Invoke(this.Coordinate);
+        }
     }
 }

--- a/unity/Assets/Scripts/TileSystem/Tile.cs
+++ b/unity/Assets/Scripts/TileSystem/Tile.cs
@@ -44,6 +44,9 @@ namespace Hexxle.TileSystem
                 case EBehaviour.Conversion:
                     tileBehaviour = new ConversionBehaviour();
                     break;
+                case EBehaviour.Consumption:
+                    tileBehaviour = new ConsumptionBehaviour();
+                    break;
                 case EBehaviour.None:
                 default:
                     tileBehaviour = null;

--- a/unity/Assets/Scripts/TileSystem/Tile.cs
+++ b/unity/Assets/Scripts/TileSystem/Tile.cs
@@ -3,6 +3,7 @@ using Hexxle.Interfaces;
 using Hexxle.TileSystem.Behaviour;
 using Hexxle.TileSystem.Nature;
 using Hexxle.TileSystem.Type;
+using System;
 
 namespace Hexxle.TileSystem
 {
@@ -13,6 +14,8 @@ namespace Hexxle.TileSystem
         private ITileType _type;
         private ITileBehaviour _behaviour;
         private ITileNature _nature;
+
+        public event Action TileChangedEvent;
 
         private Tile()
         {
@@ -98,27 +101,50 @@ namespace Hexxle.TileSystem
         public EState State
         {
             get => _state;
-            set => _state = value;
+            set
+            {
+                _state = value;
+                TileChangedEvent?.Invoke();
+            }
         }
+
         public ITileType Type
         {
             get => _type;
-            set => _type = value;
+            set
+            {
+                _type = value;
+                TileChangedEvent?.Invoke();
+            }
         }
         public ITileBehaviour Behaviour
         {
             get => _behaviour;
-            set => _behaviour = value;
+            set
+            {
+                _behaviour = value;
+                TileChangedEvent?.Invoke();
+            }
         }
         public ITileNature Nature
         {
             get => _nature;
-            set => _nature = value;
+            set
+            {
+                _nature = value;
+                TileChangedEvent?.Invoke();
+            }
         }
+
         public Coordinate Coordinate
         {
             get => _coordinate;
-            set => _coordinate = value;
+            set
+            {
+                _coordinate = value;
+                TileChangedEvent?.Invoke();
+            }
         }
+
     }
 }

--- a/unity/Assets/Scripts/Unity/Input/MouseEventsHandler.cs
+++ b/unity/Assets/Scripts/Unity/Input/MouseEventsHandler.cs
@@ -56,17 +56,6 @@ namespace Hexxle.Unity.Input
                         updateTiles();
                     }
                 }
-                else
-                {
-
-                    GameObjectFinder.UnityMap.ShowPossibleScoreForCoordinate(new Coordinate());
-                    oldTile = currentCollisionTile;
-                    currentCollisionTile = null;
-                    if (oldTile != null)
-                    {
-                        updateTiles();
-                    }
-                }
             }
         }
 

--- a/unity/Assets/Scripts/Unity/Input/MouseEventsHandler.cs
+++ b/unity/Assets/Scripts/Unity/Input/MouseEventsHandler.cs
@@ -10,6 +10,7 @@ namespace Hexxle.Unity.Input
         GameObject oldTile;
         GameObject currentCollisionTile;
         InputManager inputManager;
+        private bool isMouseOverTile;
 
         private void Awake()
         {
@@ -55,6 +56,11 @@ namespace Hexxle.Unity.Input
                         currentCollisionTile = hit.collider.gameObject;
                         updateTiles();
                     }
+                    isMouseOverTile = true;
+                }
+                else
+                {
+                    isMouseOverTile = false;
                 }
             }
         }
@@ -76,7 +82,7 @@ namespace Hexxle.Unity.Input
 
         private void MouseClickAction()
         {
-            if(currentCollisionTile != null && currentCollisionTile.CompareTag("Void"))
+            if(isMouseOverTile && currentCollisionTile != null && currentCollisionTile.CompareTag("Void"))
             {
                 UnityMap unityMap = GameObjectFinder.UnityMap;
                 Coordinate coordinate = unityMap.PointToCoordinate(currentCollisionTile.transform.position);

--- a/unity/Assets/Scripts/Unity/UnityMap.cs
+++ b/unity/Assets/Scripts/Unity/UnityMap.cs
@@ -106,26 +106,20 @@ namespace Hexxle.Unity
             return p;
         }
 
+        public ITile TileOnPoint(Vector3 point)
+        {
+            Coordinate coordinate = PointToCoordinate(point);
+            return map.GetTile(coordinate);
+        }
+
         public void OnTilePlaced(object sender, TileMapEventArgs<ITile> e)
         {
             ITile tile = e.Tile;
-            Material material;
-            material = materials[(int)e.Tile.Type.Type - 1];
             var newTile = Instantiate(
                     TileTemplate,
                     CoordinateToPoint(tile.Coordinate),
                     Quaternion.Euler(-90, 0, 0)
                 );
-            if (tile.Type.Type.Equals(EType.Void))
-            {
-                newTile.GetComponent<MeshCollider>().enabled = true;
-            } 
-            else
-            {
-                newTile.GetComponent<MeshCollider>().enabled = false;
-                newTile.tag = "Tile";
-            }
-            newTile.GetComponent<MeshRenderer>().material = material;
             newTile.transform.parent = this.transform;
         }
 

--- a/unity/Assets/Scripts/Unity/UnityStack.cs
+++ b/unity/Assets/Scripts/Unity/UnityStack.cs
@@ -66,7 +66,7 @@ namespace Hexxle.Unity
                 toDelete.Add(newTile);
                 newTile.transform.SetParent(Content.transform, false);
                 newTile.GetComponent<RawImage>().texture = texture;
-                newTile.GetComponentInChildren<TMP_Text>().text = tile.Nature.Nature.ToString();
+                newTile.GetComponentInChildren<TMP_Text>().text = tile.Nature.Nature.ToString().Substring(0,2) +  "|" + tile.Behaviour.Behaviour.ToString().Substring(0,4);
             }
             stackCount = tileStack.Count();
         }

--- a/unity/Assets/Scripts/Unity/UnityTile.cs
+++ b/unity/Assets/Scripts/Unity/UnityTile.cs
@@ -1,0 +1,53 @@
+﻿using Hexxle.CoordinateSystem;
+using Hexxle.Interfaces;
+using Hexxle.TileSystem;
+using Hexxle.Unity.Util;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Hexxle.Unity
+{
+    public class UnityTile : MonoBehaviour
+    {
+        #region Backend
+        private ITile tile;
+        #endregion
+
+        #region Unity
+        public Material[] materials;
+        #endregion
+
+        // Start is called before the first frame update
+        void Start()
+        {
+            UnityMap map = GameObjectFinder.UnityMap;
+            tile = map.TileOnPoint(transform.position);
+            
+            SetComponents();
+
+            tile.TileChangedEvent += TileChanged;
+        }
+
+        public void TileChanged()
+        {
+            SetComponents();
+        }
+
+        public void SetComponents()
+        {
+            bool isVoid = tile.Type.Type.Equals(EType.Void);
+            // Enable/disable collision
+            MeshCollider collider = GetComponent<MeshCollider>();
+            collider.enabled = isVoid ? true : false;
+
+            // Assign tag
+            if (!isVoid) tag = "Tile";
+
+            // Assign material
+            MeshRenderer renderer = GetComponent<MeshRenderer>();
+            Material material = materials[(int)tile.Type.Type - 1];
+            renderer.material = material;
+        }
+    }
+}

--- a/unity/Assets/Scripts/Unity/UnityTile.cs.meta
+++ b/unity/Assets/Scripts/Unity/UnityTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07468b90e0fb2144da819491763f27e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
+++ b/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
@@ -47,7 +47,7 @@ namespace Hexxle.Tests.Logic
             Coordinate c2 = new Coordinate(-9, -8, 17);
             tileMap.PlaceTile(tile, c1);
             tileMap.PlaceTile(tile, c2);
-            Assert.True(tileMap.TileCount() == 2);
+            Assert.True(tileMap.NonVoidTileCount() == 2);
         }
     }
 }

--- a/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
+++ b/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
@@ -60,7 +60,7 @@ namespace Hexxle.Tests.Logic
         {
             Coordinate coordinate = new Coordinate(4, 3, 2);
             tileMap.PlaceTile(tile, coordinate);
-            tileMap.RemoveTile(tile);
+            tileMap.RemoveTile(coordinate);
             Assert.IsNull(tileMap.GetTile(coordinate));
         }
 
@@ -69,12 +69,22 @@ namespace Hexxle.Tests.Logic
         {
             Coordinate coordinate = new Coordinate(4, 3, 2);
             tileMap.PlaceTile(tile, coordinate);
-            tileMap.RemoveTile(tile);
+            tileMap.RemoveTile(coordinate);
             var neighbouringCoordinates = tile.Coordinate.AdjacentCoordinates();
             var neighbouringTiles = neighbouringCoordinates.Select(coord => tileMap.GetTile(coord)).Where(tile => tile != null);
             Assert.IsTrue(neighbouringTiles.Count() == 0);
         }
 
+        [Test]
+        public void RemovalRequestedEventRemovesTile()
+        {
+            Coordinate coordinate = new Coordinate(4, 3, 2);
+            tileMap.PlaceTile(tile, coordinate);
+            tile.RequestRemoval();
+            Assert.IsNull(tileMap.GetTile(coordinate));
+        }
+
+        #region Issue specific tests
         [Test]
         public void PlaceTile_Hexxle91()
         {
@@ -85,5 +95,6 @@ namespace Hexxle.Tests.Logic
             explicitTileMap.PlaceTile(tile, c2);
             Assert.True(explicitTileMap.NonVoidTileCount() == 2);
         }
+        #endregion
     }
 }

--- a/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
+++ b/unity/Assets/Tests/EditMode/Logic/TileMapTests.cs
@@ -2,15 +2,16 @@
 using Hexxle.Logic;
 using Hexxle.TileSystem;
 using Hexxle.CoordinateSystem;
-
+using System.Linq;
+using Hexxle.Interfaces;
 
 namespace Hexxle.Tests.Logic
 {
     public class TileMapTests
     {
 
-        TileMap tileMap;
-        Tile tile;
+        ITileMap<ITile> tileMap;
+        ITile tile;
 
         [SetUp]
         public void Setup()
@@ -41,13 +42,48 @@ namespace Hexxle.Tests.Logic
         }
 
         [Test]
+        public void PlacedTileHasVoidNeighbours()
+        {
+            Coordinate coordinate = new Coordinate(4, 3, 2);
+            tileMap.PlaceTile(tile, coordinate);
+            var neighbouringCoordinates = tile.Coordinate.AdjacentCoordinates();
+            var neighbouringTiles = neighbouringCoordinates.Select(coord => tileMap.GetTile(coord)).Where(tile => tile != null);
+            Assert.AreEqual(neighbouringTiles.Count(), 6);
+            foreach (ITile neighbouringTile in neighbouringTiles)
+            {
+                Assert.IsTrue(neighbouringTile.Type.Type == EType.Void);
+            }
+        }
+
+        [Test]
+        public void PlacedTileCanBeRemoved()
+        {
+            Coordinate coordinate = new Coordinate(4, 3, 2);
+            tileMap.PlaceTile(tile, coordinate);
+            tileMap.RemoveTile(tile);
+            Assert.IsNull(tileMap.GetTile(coordinate));
+        }
+
+        [Test]
+        public void OrphanedTilesAreRemoved()
+        {
+            Coordinate coordinate = new Coordinate(4, 3, 2);
+            tileMap.PlaceTile(tile, coordinate);
+            tileMap.RemoveTile(tile);
+            var neighbouringCoordinates = tile.Coordinate.AdjacentCoordinates();
+            var neighbouringTiles = neighbouringCoordinates.Select(coord => tileMap.GetTile(coord)).Where(tile => tile != null);
+            Assert.IsTrue(neighbouringTiles.Count() == 0);
+        }
+
+        [Test]
         public void PlaceTile_Hexxle91()
         {
+            TileMap explicitTileMap = new TileMap();
             Coordinate c1 = new Coordinate(-8, -8, 16);
             Coordinate c2 = new Coordinate(-9, -8, 17);
-            tileMap.PlaceTile(tile, c1);
-            tileMap.PlaceTile(tile, c2);
-            Assert.True(tileMap.NonVoidTileCount() == 2);
+            explicitTileMap.PlaceTile(tile, c1);
+            explicitTileMap.PlaceTile(tile, c2);
+            Assert.True(explicitTileMap.NonVoidTileCount() == 2);
         }
     }
 }

--- a/unity/Assets/Tests/EditMode/TileSystem/Behaviour.meta
+++ b/unity/Assets/Tests/EditMode/TileSystem/Behaviour.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 617c11ffdbb52034b946783fbd8a43f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/EditMode/TileSystem/Behaviour/BehaviourTests.cs
+++ b/unity/Assets/Tests/EditMode/TileSystem/Behaviour/BehaviourTests.cs
@@ -1,0 +1,45 @@
+﻿using Hexxle.Interfaces;
+using Hexxle.TileSystem;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hexxle.Tests.TileSystem.Behaviour
+{
+    public class BehaviourTests
+    {
+        ITile originalTile;
+        ITile otherTile;
+
+        [SetUp]
+        public void Setup()
+        {
+            originalTile = null;
+            otherTile = Tile.CreateInstance(EState.None, EType.Green, ENature.Circle, EBehaviour.None);
+        }
+
+        [Test]
+        public void NoEffect()
+        {
+            EType expectedType = otherTile.Type.Type;
+
+            originalTile = Tile.CreateInstance(EState.None, EType.Red, ENature.Circle, EBehaviour.NoEffect);
+            originalTile.Behaviour.ApplyBehaviour(originalTile, otherTile);
+
+            Assert.IsTrue(otherTile.Type.Type.Equals(expectedType));
+        }
+
+        [Test]
+        public void Conversion()
+        {
+            originalTile = Tile.CreateInstance(EState.None, EType.Red, ENature.Circle, EBehaviour.Conversion);
+            originalTile.Behaviour.ApplyBehaviour(originalTile, otherTile);
+
+            EType expectedType = originalTile.Type.Type;
+            Assert.IsTrue(otherTile.Type.Type.Equals(expectedType));
+        }
+    }
+}

--- a/unity/Assets/Tests/EditMode/TileSystem/Behaviour/BehaviourTests.cs.meta
+++ b/unity/Assets/Tests/EditMode/TileSystem/Behaviour/BehaviourTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 834177e320a33904a84b377ecb965e50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Tests/EditMode/TileSystem/Nature/NatureTests.cs
+++ b/unity/Assets/Tests/EditMode/TileSystem/Nature/NatureTests.cs
@@ -13,8 +13,8 @@ namespace Hexxle.Tests.TileSystem.Nature
     public class NatureTests
     {
         ITile tile;
-        List<Coordinate> expectedCoordinates;
-        List<Coordinate> actualCoordinates;
+        IEnumerable<Coordinate> expectedCoordinates;
+        IEnumerable<Coordinate> actualCoordinates;
         Coordinate coordinate;
 
         [SetUp]
@@ -38,7 +38,7 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Circle, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.AddRange(new List<Coordinate>
+            expectedCoordinates.Concat(new List<Coordinate>
             {
                 new Coordinate(coordinate.X + 1, coordinate.Y - 1, coordinate.Z),
                 new Coordinate(coordinate.X + 1, coordinate.Y, coordinate.Z - 1),
@@ -50,10 +50,10 @@ namespace Hexxle.Tests.TileSystem.Nature
 
             actualCoordinates = tile.Nature.RelevantCoordinates(tile.Coordinate);
 
-            expectedCoordinates.ForEach(coord =>
+            foreach (Coordinate coord in expectedCoordinates)
             {
                 Assert.True(actualCoordinates.Contains(coord));
-            });
+            }
         }
 
         [Test]
@@ -64,14 +64,14 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Circle, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.AddRange(tile.Nature.AdjacentCoordinates(tile.Coordinate));
+            expectedCoordinates.Concat(tile.Nature.AdjacentCoordinates(tile.Coordinate));
 
             actualCoordinates = tile.Nature.RelevantCoordinates(origin);
 
-            expectedCoordinates.ForEach(coord =>
+            foreach (Coordinate coord in expectedCoordinates)
             {
                 Assert.True(actualCoordinates.Contains(coord));
-            });
+            }
         }
 
         [Test]
@@ -82,8 +82,8 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Star, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.AddRange(tile.Nature.AdjacentCoordinates(tile.Coordinate));
-            expectedCoordinates.AddRange(new List<Coordinate>
+            expectedCoordinates.Concat(tile.Nature.AdjacentCoordinates(tile.Coordinate));
+            expectedCoordinates.Concat(new List<Coordinate>
             {
                 new Coordinate(coordinate.X - 1, coordinate.Y - 1, coordinate.Z + 2),
                 new Coordinate(coordinate.X + 1, coordinate.Y - 2, coordinate.Z + 1),
@@ -95,10 +95,10 @@ namespace Hexxle.Tests.TileSystem.Nature
 
             actualCoordinates = tile.Nature.RelevantCoordinates(origin);
 
-            expectedCoordinates.ForEach(coord =>
+            foreach (Coordinate coord in expectedCoordinates)
             {
                 Assert.True(actualCoordinates.Contains(coord));
-            });
+            }
         }
     }
 }

--- a/unity/Assets/Tests/EditMode/TileSystem/Nature/NatureTests.cs
+++ b/unity/Assets/Tests/EditMode/TileSystem/Nature/NatureTests.cs
@@ -38,7 +38,7 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Circle, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.Concat(new List<Coordinate>
+            expectedCoordinates = expectedCoordinates.Union(new List<Coordinate>
             {
                 new Coordinate(coordinate.X + 1, coordinate.Y - 1, coordinate.Z),
                 new Coordinate(coordinate.X + 1, coordinate.Y, coordinate.Z - 1),
@@ -50,9 +50,9 @@ namespace Hexxle.Tests.TileSystem.Nature
 
             actualCoordinates = tile.Nature.RelevantCoordinates(tile.Coordinate);
 
-            foreach (Coordinate coord in expectedCoordinates)
+            foreach (Coordinate coord in actualCoordinates)
             {
-                Assert.True(actualCoordinates.Contains(coord));
+                Assert.True(expectedCoordinates.Contains(coord));
             }
         }
 
@@ -64,13 +64,13 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Circle, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.Concat(tile.Coordinate.AdjacentCoordinates());
+            expectedCoordinates = expectedCoordinates.Union(tile.Coordinate.AdjacentCoordinates());
 
             actualCoordinates = tile.Nature.RelevantCoordinates(origin);
 
-            foreach (Coordinate coord in expectedCoordinates)
+            foreach (Coordinate coord in actualCoordinates)
             {
-                Assert.True(actualCoordinates.Contains(coord));
+                Assert.True(expectedCoordinates.Contains(coord));
             }
         }
 
@@ -82,8 +82,8 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Star, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.Concat(tile.Coordinate.AdjacentCoordinates());
-            expectedCoordinates.Concat(new List<Coordinate>
+            expectedCoordinates = expectedCoordinates.Union(tile.Coordinate.AdjacentCoordinates());
+            expectedCoordinates = expectedCoordinates.Union(new List<Coordinate>
             {
                 new Coordinate(coordinate.X - 1, coordinate.Y - 1, coordinate.Z + 2),
                 new Coordinate(coordinate.X + 1, coordinate.Y - 2, coordinate.Z + 1),
@@ -95,9 +95,9 @@ namespace Hexxle.Tests.TileSystem.Nature
 
             actualCoordinates = tile.Nature.RelevantCoordinates(origin);
 
-            foreach (Coordinate coord in expectedCoordinates)
+            foreach (Coordinate coord in actualCoordinates)
             {
-                Assert.True(actualCoordinates.Contains(coord));
+                Assert.True(expectedCoordinates.Contains(coord));
             }
         }
     }

--- a/unity/Assets/Tests/EditMode/TileSystem/Nature/NatureTests.cs
+++ b/unity/Assets/Tests/EditMode/TileSystem/Nature/NatureTests.cs
@@ -64,7 +64,7 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Circle, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.Concat(tile.Nature.AdjacentCoordinates(tile.Coordinate));
+            expectedCoordinates.Concat(tile.Coordinate.AdjacentCoordinates());
 
             actualCoordinates = tile.Nature.RelevantCoordinates(origin);
 
@@ -82,7 +82,7 @@ namespace Hexxle.Tests.TileSystem.Nature
             tile = Tile.CreateInstance(EState.None, EType.None, ENature.Star, EBehaviour.None);
             tile.Coordinate = origin;
 
-            expectedCoordinates.Concat(tile.Nature.AdjacentCoordinates(tile.Coordinate));
+            expectedCoordinates.Concat(tile.Coordinate.AdjacentCoordinates());
             expectedCoordinates.Concat(new List<Coordinate>
             {
                 new Coordinate(coordinate.X - 1, coordinate.Y - 1, coordinate.Z + 2),

--- a/unity/Assets/Tests/EditMode/TileSystem/TileTests.cs
+++ b/unity/Assets/Tests/EditMode/TileSystem/TileTests.cs
@@ -1,6 +1,9 @@
-﻿using Hexxle.Interfaces;
+﻿using Hexxle.CoordinateSystem;
+using Hexxle.Interfaces;
 using Hexxle.TileSystem;
 using Hexxle.TileSystem.Behaviour;
+using Hexxle.TileSystem.Nature;
+using Hexxle.TileSystem.Type;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -13,6 +16,12 @@ namespace Hexxle.Tests.TileSystem
     public class TileTests
     {
         ITile tile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            tile = Tile.CreateInstance(EState.None, EType.None, ENature.None, EBehaviour.None);
+        }
 
         [Test]
         public void CreateInstance_Test()
@@ -88,6 +97,51 @@ namespace Hexxle.Tests.TileSystem
                 ITile tile = Tile.CreateInstance(EState.None, EType.None, ENature.None, behaviour);
                 Assert.NotNull(tile.Behaviour);
             }
+        }
+
+        [Test]
+        public void TileChangedEventFires_State()
+        {
+            bool eventFired = false;
+            tile.TileChangedEvent += () => eventFired = true;
+            tile.State = EState.OnField;
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void TileChangedEventFires_Coordinate()
+        {
+            bool eventFired = false;
+            tile.TileChangedEvent += () => eventFired = true;
+            tile.Coordinate = new Coordinate(5, 5, 5);
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void TileChangedEventFires_Type()
+        {
+            bool eventFired = false;
+            tile.TileChangedEvent += () => eventFired = true;
+            tile.Type = new RedType();
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void TileChangedEventFires_Behaviour()
+        {
+            bool eventFired = false;
+            tile.TileChangedEvent += () => eventFired = true;
+            tile.Behaviour = new ConversionBehaviour();
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void TileChangedEventFires_Nature()
+        {
+            bool eventFired = false;
+            tile.TileChangedEvent += () => eventFired = true;
+            tile.Nature = new StarNature();
+            Assert.IsTrue(eventFired);
         }
     }
 }

--- a/unity/Assets/Tests/EditMode/TileSystem/TileTests.cs
+++ b/unity/Assets/Tests/EditMode/TileSystem/TileTests.cs
@@ -1,5 +1,6 @@
 ﻿using Hexxle.CoordinateSystem;
 using Hexxle.Interfaces;
+using Hexxle.Logic;
 using Hexxle.TileSystem;
 using Hexxle.TileSystem.Behaviour;
 using Hexxle.TileSystem.Nature;
@@ -141,6 +142,15 @@ namespace Hexxle.Tests.TileSystem
             bool eventFired = false;
             tile.TileChangedEvent += () => eventFired = true;
             tile.Nature = new StarNature();
+            Assert.IsTrue(eventFired);
+        }
+
+        [Test]
+        public void RemovalRequestedEventFires()
+        {
+            bool eventFired = false;
+            tile.RemovalRequestedEvent += (Coordinate c) => eventFired = true;
+            tile.RequestRemoval();
             Assert.IsTrue(eventFired);
         }
     }

--- a/unity/EditMode.csproj
+++ b/unity/EditMode.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Assets\Tests\EditMode\Logic\HandTests.cs" />
     <Compile Include="Assets\Tests\EditMode\Logic\ScoreTests.cs" />
     <Compile Include="Assets\Tests\EditMode\Logic\TileMapTests.cs" />
+    <Compile Include="Assets\Tests\EditMode\TileSystem\Behaviour\BehaviourTests.cs" />
     <Compile Include="Assets\Tests\EditMode\TileSystem\Nature\NatureTests.cs" />
     <Compile Include="Assets\Tests\EditMode\TileSystem\TileTests.cs" />
     <Compile Include="Assets\Tests\EditMode\TileSystem\Type\TypeTests.cs" />

--- a/unity/Scripts.csproj
+++ b/unity/Scripts.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Assets\Scripts\Logic\TileMap.cs" />
     <Compile Include="Assets\Scripts\Logic\TileResolver.cs" />
     <Compile Include="Assets\Scripts\Logic\TileStack.cs" />
+    <Compile Include="Assets\Scripts\TileSystem\Behaviour\ConsumptionBehaviour.cs" />
+    <Compile Include="Assets\Scripts\TileSystem\Behaviour\ConversionBehaviour.cs" />
     <Compile Include="Assets\Scripts\TileSystem\Behaviour\NoEffectBehaviour.cs" />
     <Compile Include="Assets\Scripts\TileSystem\EBehaviour.cs" />
     <Compile Include="Assets\Scripts\TileSystem\ENature.cs" />

--- a/unity/Scripts.csproj
+++ b/unity/Scripts.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Assets\Scripts\Unity\UnityPoints.cs" />
     <Compile Include="Assets\Scripts\Unity\UnityPossiblePoints.cs" />
     <Compile Include="Assets\Scripts\Unity\UnityStack.cs" />
+    <Compile Include="Assets\Scripts\Unity\UnityTile.cs" />
     <Compile Include="Assets\Scripts\Unity\UnityTileHighlighter.cs" />
     <Compile Include="Assets\Scripts\Unity\UnityTitlescreen.cs" />
     <Compile Include="Assets\Scripts\Unity\UnityUI.cs" />


### PR DESCRIPTION
Added two new behaviours:
* Conversion -> changes type of relevant tiles to its own type
*  Consumption -> removes relevant tiles from the map

Visual tile logic is now centered in UnityTile. UnityTile is notified of any changes to the underlying Tile object and will change it's visuals accordingly.

UnityMap now keeps track of instantiated GameObjects.